### PR TITLE
docs: fix license reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,5 +84,5 @@ This was only tested using a max of 2 nodes if you have more please test and rep
 
 ## License
 
-This project is licensed under the GPL 3.0 License - see the `LICENSE.md` file for details.
+This project is licensed under the GPL 3.0 License - see the `LICENSE` file for details.
 


### PR DESCRIPTION
## Summary
- correct README to refer to LICENSE file

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cd52665f08329906dedc4794b8b1f