### PR TITLE
Add play area marker type

### DIFF
--- a/app/src/main/java/io/github/fieldmesh/MainActivity.java
+++ b/app/src/main/java/io/github/fieldmesh/MainActivity.java
@@ -129,12 +129,13 @@ public class MainActivity extends AppCompatActivity implements LocationListener,
     private static final int EDIT_MODE_LINE = 2;
     private static final int EDIT_MODE_POLY = 3;
     private static final int EDIT_MODE_CIRCLE = 4;
+    private static final int EDIT_MODE_PLAY_AREA = 5;
 
     private static MapView mapView = null;
     private IMapController mapController = null;
 
     private ImageButton btnTileToggle, btnFollowToggle, btnRotateToggle, launchMeshtasticButton,
-            addPinButton, addLineButton, addPolyButton, addCircleButton,
+            addPinButton, addLineButton, addPolyButton, addCircleButton, addPlayAreaButton,
             undoButton, closeButton, doneButton, infoButton, toggleGridButton, searchButton, squadButton;
     private LocationManager locationManager;
     private SensorManager sensorManager;
@@ -167,6 +168,8 @@ public class MainActivity extends AppCompatActivity implements LocationListener,
     private List<GeoPoint> currentPolygonPoints = new ArrayList<>();
     private Polygon temporaryPolygonOverlay;
     private List<Polygon> drawnPolygons = new ArrayList<>();
+    private Polygon playAreaMask;
+    private Polygon playAreaBoundary;
     private Handler periodicNodeUpdateHandler;
     private Runnable nodeUpdateRunnable;
     private static final long NODE_UPDATE_INTERVAL_MS = 10 * 1000;
@@ -346,6 +349,7 @@ public class MainActivity extends AppCompatActivity implements LocationListener,
         addCircleButton = findViewById(R.id.btn_circle_add);
         addLineButton = findViewById(R.id.btn_line_add);
         addPolyButton = findViewById(R.id.btn_poly_add);
+        addPlayAreaButton = findViewById(R.id.btn_playarea_add);
         searchButton = findViewById(R.id.searchButton);
         undoButton = findViewById(R.id.undo);
         closeButton = findViewById(R.id.close);
@@ -566,6 +570,19 @@ public class MainActivity extends AppCompatActivity implements LocationListener,
             Toast.makeText(this, R.string.polyEditingMode, Toast.LENGTH_SHORT).show();
         });
 
+        addPlayAreaButton.setOnClickListener(v -> {
+            clearAllTemporaryDrawingStates();
+            IS_EDIT_MODE = EDIT_MODE_PLAY_AREA;
+            currentPolygonPoints.clear();
+            if (temporaryPolygonOverlay != null) mapView.getOverlays().remove(temporaryPolygonOverlay);
+            temporaryPolygonOverlay = null;
+            editingTools.setVisibility(View.VISIBLE);
+            info.setVisibility(View.GONE);
+            toolMenu.setVisibility(View.GONE);
+            toggleTools.setVisibility(View.GONE);
+            Toast.makeText(this, R.string.playAreaEditingMode, Toast.LENGTH_SHORT).show();
+        });
+
         addCircleButton.setOnClickListener(v -> {
             clearAllTemporaryDrawingStates();
             IS_EDIT_MODE = EDIT_MODE_CIRCLE;
@@ -601,6 +618,15 @@ public class MainActivity extends AppCompatActivity implements LocationListener,
                         Toast.makeText(this, "Last polygon point removed.", Toast.LENGTH_SHORT).show();
                     } else {
                         Toast.makeText(this, "No polygon points to remove.", Toast.LENGTH_SHORT).show();
+                    }
+                    break;
+                case EDIT_MODE_PLAY_AREA:
+                    if (!currentPolygonPoints.isEmpty()) {
+                        currentPolygonPoints.remove(currentPolygonPoints.size() - 1);
+                        updateTemporaryPolygonOverlay();
+                        Toast.makeText(this, "Last play area point removed.", Toast.LENGTH_SHORT).show();
+                    } else {
+                        Toast.makeText(this, "No play area points to remove.", Toast.LENGTH_SHORT).show();
                     }
                     break;
                 case EDIT_MODE_CIRCLE:
@@ -644,6 +670,13 @@ public class MainActivity extends AppCompatActivity implements LocationListener,
                         showShapeSquadSelectionDialog();
                     } else {
                         Toast.makeText(this, "A polygon needs at least 3 points.", Toast.LENGTH_SHORT).show();
+                    }
+                    break;
+                case EDIT_MODE_PLAY_AREA:
+                    if (currentPolygonPoints.size() >= 3) {
+                        showShapeColorSelectionDialog((byte)0);
+                    } else {
+                        Toast.makeText(this, R.string.playAreaNeedPoints, Toast.LENGTH_SHORT).show();
                     }
                     break;
                 case EDIT_MODE_CIRCLE:
@@ -955,6 +988,16 @@ public class MainActivity extends AppCompatActivity implements LocationListener,
                     }
                     handled = true;
                     break;
+                case EDIT_MODE_PLAY_AREA:
+                    if (currentPolygonPoints.size() < 15) {
+                        currentPolygonPoints.add(p);
+                        updateTemporaryPolygonOverlay();
+                        Toast.makeText(this, "Point " + currentPolygonPoints.size() + " added.", Toast.LENGTH_SHORT).show();
+                    } else {
+                        Toast.makeText(this, R.string.playAreaMaxPoints, Toast.LENGTH_SHORT).show();
+                    }
+                    handled = true;
+                    break;
                 case EDIT_MODE_CIRCLE:
                     if (circleCenter == null) {
                         circleCenter = p;
@@ -1190,6 +1233,25 @@ public class MainActivity extends AppCompatActivity implements LocationListener,
                 Toast.makeText(this, "Polygon added.", Toast.LENGTH_SHORT).show();
                 clearTemporaryPolygonState();
                 dataChangedForWear = true;
+            } else if (IS_EDIT_MODE == EDIT_MODE_PLAY_AREA && currentPolygonPoints.size() >= 3) {
+                mapDataDbHelper.deletePlayArea();
+
+                PolygonInfo playInfo = new PolygonInfo();
+                playInfo.setSquadId((byte) 0);
+                playInfo.setPoints(currentPolygonPoints);
+                playInfo.setColor(colorIndex);
+                playInfo.setLabel("PLAYAREA");
+
+                drawPlayArea(new ArrayList<>(currentPolygonPoints), actualColorValue);
+                mapDataDbHelper.addPolygon(playInfo);
+
+                if (isGeeksvilleMeshServiceActivityBound && geeksvilleMeshServiceActivity != null) {
+                    MeshtasticConnector.sendData(geeksvilleMeshServiceActivity, playInfo.encode(), "POLY", DataPacket.ID_BROADCAST);
+                }
+
+                Toast.makeText(this, R.string.playAreaAdded, Toast.LENGTH_SHORT).show();
+                clearTemporaryPolygonState();
+                dataChangedForWear = true;
             }
 
             resetEditingMode();
@@ -1355,6 +1417,47 @@ public class MainActivity extends AppCompatActivity implements LocationListener,
 
         mapView.getOverlays().add(0, circlePolygon);
         drawnPolygons.add(circlePolygon);
+        mapView.invalidate();
+    }
+
+    private void drawPlayArea(List<GeoPoint> points, int color) {
+        if (mapView == null || points == null || points.size() < 3) return;
+
+        if (playAreaMask != null) {
+            mapView.getOverlays().remove(playAreaMask);
+        }
+        if (playAreaBoundary != null) {
+            mapView.getOverlays().remove(playAreaBoundary);
+        }
+
+        List<GeoPoint> outer = new ArrayList<>();
+        outer.add(new GeoPoint(-85, -180));
+        outer.add(new GeoPoint(-85, 180));
+        outer.add(new GeoPoint(85, 180));
+        outer.add(new GeoPoint(85, -180));
+
+        Polygon mask = new Polygon(mapView);
+        mask.setPoints(outer);
+        List<List<GeoPoint>> holes = new ArrayList<>();
+        holes.add(new ArrayList<>(points));
+        mask.setHoles(holes);
+        int fillColor = Color.argb(100, Color.red(color), Color.green(color), Color.blue(color));
+        mask.getFillPaint().setColor(fillColor);
+        mask.getOutlinePaint().setColor(Color.TRANSPARENT);
+        mask.setInfoWindow(null);
+
+        Polygon boundary = new Polygon(mapView);
+        boundary.setPoints(new ArrayList<>(points));
+        boundary.getFillPaint().setColor(Color.TRANSPARENT);
+        boundary.getOutlinePaint().setColor(color);
+        boundary.getOutlinePaint().setStrokeWidth(7f * getResources().getDisplayMetrics().density);
+        boundary.setInfoWindow(null);
+
+        mapView.getOverlays().add(mask);
+        mapView.getOverlays().add(boundary);
+
+        playAreaMask = mask;
+        playAreaBoundary = boundary;
         mapView.invalidate();
     }
 
@@ -1942,7 +2045,11 @@ public class MainActivity extends AppCompatActivity implements LocationListener,
             if (points != null && points.size() >=3) {
                 int colorResId = ColorIndex.getColorByIndex(polygonInfo.getColor());
                 int actualColorValue = ContextCompat.getColor(this, colorResId);
-                drawFinalPolygon(points, actualColorValue, polygonInfo.getUniqueId(), SquadIndex.getNameById(polygonInfo.getSquadId()));
+                if ("PLAYAREA".equalsIgnoreCase(polygonInfo.getLabel())) {
+                    drawPlayArea(points, actualColorValue);
+                } else {
+                    drawFinalPolygon(points, actualColorValue, polygonInfo.getUniqueId(), SquadIndex.getNameById(polygonInfo.getSquadId()));
+                }
             }
         }
     }
@@ -2013,6 +2120,15 @@ public class MainActivity extends AppCompatActivity implements LocationListener,
             mapView.getOverlays().remove(polygon);
         }
         drawnPolygons.clear();
+
+        if (playAreaMask != null) {
+            mapView.getOverlays().remove(playAreaMask);
+            playAreaMask = null;
+        }
+        if (playAreaBoundary != null) {
+            mapView.getOverlays().remove(playAreaBoundary);
+            playAreaBoundary = null;
+        }
         mapView.invalidate();
     }
 

--- a/app/src/main/java/io/github/fieldmesh/MapDataDatabaseHelper.java
+++ b/app/src/main/java/io/github/fieldmesh/MapDataDatabaseHelper.java
@@ -844,6 +844,19 @@ public class MapDataDatabaseHelper extends SQLiteOpenHelper {
         return rowsDeleted;
     }
 
+    /**
+     * Remove any existing play area polygon from the database. A play area is
+     * stored as a polygon with the label "PLAYAREA".
+     */
+    public void deletePlayArea() {
+        SQLiteDatabase db = this.getWritableDatabase();
+        db.delete(
+                TABLE_MAP_OBJECTS,
+                COLUMN_MO_OBJECT_TYPE + " = ? AND " + COLUMN_MO_LABEL + " = ?",
+                new String[]{OBJECT_TYPE_POLYGON, "PLAYAREA"}
+        );
+    }
+
 
     public String getDatabaseHash() {
         SQLiteDatabase db = null;

--- a/app/src/main/res/drawable/addplayarea.xml
+++ b/app/src/main/res/drawable/addplayarea.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+  <path
+      android:pathData="M69.5,44.61V67.46H45.85v7.77h23.65v22.77h8.11V75.23H99.59V67.46H77.61V44.61Z"
+      android:strokeWidth="0.135805"
+      android:fillColor="#ff0000"
+      android:strokeColor="#00000000"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M80.77,9.63 L15.71,11.66 8.79,83.64 37.34,92.6 37.51,58.47Z"
+      android:strokeWidth="8.239"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -210,6 +210,18 @@
         android:visibility="gone">
 
         <ImageButton
+            android:id="@+id/btn_playarea_add"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="@drawable/button_round_background"
+            android:clickable="true"
+            android:focusable="true"
+            android:scaleType="fitCenter"
+            android:src="@drawable/addplayarea"
+            android:layout_marginRight="10dp"
+            android:padding="10dp"/>
+
+        <ImageButton
             android:id="@+id/btn_circle_add"
             android:layout_width="48dp"
             android:layout_height="48dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="rNameAPC">APC</string>
     <string name="rNameAntiAir">ANTIAIR</string>
     <string name="rNameTank">TANK</string>
-    <string name="rNameColorWhite">White</string>">
+    <string name="rNameColorWhite">White</string>
     <string name="rNameColorRed">Red</string>
     <string name="rNameColorYellow">Yellow</string>
     <string name="rNameColorBlack">Black</string>
@@ -36,18 +36,23 @@
     <string name="intValueRangeWarning">The color value should be between 0 and 3.</string>
     <string name="lineTypeWarning">The line type value should be between 0 and 1.</string>
     <string name="lineMaxPointsWarning">The line must have a maximum of 15 points.</string>
-    <string name="rotationWarning">The rotation value should be between 0 and 360.</string>"
-    <string name="iconValueRangeWarning">The icon value should be between 0 and 99.</string>"
-    <string name="closedEditing">Stopped editing.</string>"
-    <string name="sentToMesh">Done. Sent to Mesh.</string>"
+    <string name="rotationWarning">The rotation value should be between 0 and 360.</string>
+    <string name="iconValueRangeWarning">The icon value should be between 0 and 99.</string>
+    <string name="closedEditing">Stopped editing.</string>
+    <string name="sentToMesh">Done. Sent to Mesh.</string>
     <string name="circleEditingMode">tap to Select circle center and radius.</string>
     <string name="lineEditingMode">Tap to select line points.</string>
     <string name="polyEditingMode">Tap to select polygon points.</string>
     <string name="pinEditingMode">Tap to select pin location.</string>
     <string name="icon_preview">Icon preview</string>
-    <string name="rBiohazard">BIOHAZARD</string>"
+    <string name="rBiohazard">BIOHAZARD</string>
     <string name="rExclamation">WARNING</string>
     <string name="rRadioactive">NUCLEAR</string>
     <string name="mesh_service_channel_name">FieldMesh Service</string>
     <string name="mesh_service_channel_description">Handles background FieldMesh data.</string>
+
+    <string name="playAreaEditingMode">Tap to select play area boundary points.</string>
+    <string name="playAreaAdded">Play area added.</string>
+    <string name="playAreaNeedPoints">A play area needs at least 3 points.</string>
+    <string name="playAreaMaxPoints">Max 15 points for a play area.</string>
 </resources>


### PR DESCRIPTION
## Summary
- shade map outside user-defined play area by rendering a mask over the rest of the world
- store play area polygon and broadcast it to the mesh network for sync
- remove prior play area overlays when reloading map data

## Testing
- `bash ./gradlew test` *(fails: SDK location not found)*
- `apt-get install -y android-sdk` *(command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689cf217a76c8329812e8d926391b7d6