### PR TITLE
Add dedicated play area sync logic

### DIFF
--- a/app/src/main/java/io/github/fieldmesh/MainActivity.java
+++ b/app/src/main/java/io/github/fieldmesh/MainActivity.java
@@ -1273,7 +1273,7 @@ public class MainActivity extends AppCompatActivity implements LocationListener,
                 mapDataDbHelper.addPolygon(playInfo);
 
                 if (isGeeksvilleMeshServiceActivityBound && geeksvilleMeshServiceActivity != null) {
-                    MeshtasticConnector.sendData(geeksvilleMeshServiceActivity, playInfo.encode(), "POLY", DataPacket.ID_BROADCAST);
+                    MeshtasticConnector.sendData(geeksvilleMeshServiceActivity, playInfo.encode(), "PLAY_AREA", DataPacket.ID_BROADCAST);
                 }
                 Toast.makeText(this, "Play area added.", Toast.LENGTH_SHORT).show();
                 clearTemporaryPolygonState();

--- a/app/src/main/java/io/github/fieldmesh/MapDataDatabaseHelper.java
+++ b/app/src/main/java/io/github/fieldmesh/MapDataDatabaseHelper.java
@@ -655,7 +655,7 @@ public class MapDataDatabaseHelper extends SQLiteOpenHelper {
         String objectType = null;
 
         try {
-            String[] columns = {COLUMN_MO_OBJECT_TYPE};
+            String[] columns = {COLUMN_MO_OBJECT_TYPE, COLUMN_MO_LABEL};
             String selection = COLUMN_MO_UNIQUE_ID + " = ?";
             String[] selectionArgs = {uniqueId};
 
@@ -671,6 +671,12 @@ public class MapDataDatabaseHelper extends SQLiteOpenHelper {
 
             if (cursor != null && cursor.moveToFirst()) {
                 objectType = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_MO_OBJECT_TYPE));
+                if (OBJECT_TYPE_POLYGON.equals(objectType)) {
+                    String label = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_MO_LABEL));
+                    if ("PLAY_AREA".equals(label)) {
+                        objectType = "PLAY_AREA";
+                    }
+                }
             }
         } catch (Exception e) {
             Log.e(TAG, "Error getting object type for uniqueId '" + uniqueId + "': " + e.getMessage(), e);

--- a/app/src/main/java/io/github/fieldmesh/MeshReceiverService.java
+++ b/app/src/main/java/io/github/fieldmesh/MeshReceiverService.java
@@ -388,8 +388,19 @@ public class MeshReceiverService extends Service implements MessageClient.OnMess
                                         case "PIN": PinInfo pin = mapDataDbHelper.getPin(uuidToSend); if (pin != null) MeshtasticConnector.sendData(geeksvilleMeshService, pin.encode(), "PIN", syncingWithNodeId); break;
                                         case "CIRCLE": CircleInfo circle = mapDataDbHelper.getCircle(uuidToSend); if (circle != null) MeshtasticConnector.sendData(geeksvilleMeshService, circle.encode(), "CIRCLE", syncingWithNodeId); break;
                                         case "LINE": LineInfo line = mapDataDbHelper.getLine(uuidToSend); if (line != null) MeshtasticConnector.sendData(geeksvilleMeshService, line.encode(), "LINE", syncingWithNodeId); break;
-                                        case "POLYGON": PolygonInfo polygon = mapDataDbHelper.getPolygon(uuidToSend); if (polygon != null) MeshtasticConnector.sendData(geeksvilleMeshService, polygon.encode(), "POLY", syncingWithNodeId); break;
-                                        default: Log.w(TAG, "ServiceReceiver: Unknown type '" + type + "' for UUID " + uuidToSend + " to send."); break;
+                                        case "POLYGON":
+                                            PolygonInfo polygon = mapDataDbHelper.getPolygon(uuidToSend);
+                                            if (polygon != null)
+                                                MeshtasticConnector.sendData(geeksvilleMeshService, polygon.encode(), "POLY", syncingWithNodeId);
+                                            break;
+                                        case "PLAY_AREA":
+                                            PolygonInfo playArea = mapDataDbHelper.getPolygon(uuidToSend);
+                                            if (playArea != null)
+                                                MeshtasticConnector.sendData(geeksvilleMeshService, playArea.encode(), "PLAY_AREA", syncingWithNodeId);
+                                            break;
+                                        default:
+                                            Log.w(TAG, "ServiceReceiver: Unknown type '" + type + "' for UUID " + uuidToSend + " to send.");
+                                            break;
                                     }
                                 } else {
                                     Log.w(TAG, "ServiceReceiver: Requested UUID " + uuidToSend + " not found or is already (soft)deleted locally, not sending.");
@@ -414,6 +425,7 @@ public class MeshReceiverService extends Service implements MessageClient.OnMess
                     case "PIN":
                     case "LINE":
                     case "POLY":
+                    case "PLAY_AREA":
                     case "CIRCLE":
                     case "SEND_UUID_DATA":
                         String actualItemUuid = null;
@@ -462,6 +474,18 @@ public class MeshReceiverService extends Service implements MessageClient.OnMess
                                     itemAdded = true;
                                 } else {
                                     Log.i(TAG, "ServiceReceiver: (Inner) POLYGON " + actualItemUuid + " from " + fromNodeId + " already exists. IGNORED.");
+                                }
+                                break;
+                            case "PLAY_AREA":
+                                PolygonInfo playAreaPoly = new PolygonInfo();
+                                playAreaPoly.decode(actualItemData);
+                                actualItemUuid = playAreaPoly.getUniqueId();
+                                if (!mapDataDbHelper.objectExists(actualItemUuid)) {
+                                    mapDataDbHelper.addPolygon(playAreaPoly);
+                                    Log.i(TAG, "ServiceReceiver: (Inner) PLAY_AREA " + actualItemUuid + " ADDED NEW from " + fromNodeId);
+                                    itemAdded = true;
+                                } else {
+                                    Log.i(TAG, "ServiceReceiver: (Inner) PLAY_AREA " + actualItemUuid + " from " + fromNodeId + " already exists. IGNORED.");
                                 }
                                 break;
                             case "CIRCLE":

--- a/app/src/main/java/io/github/fieldmesh/MeshtasticConnector.java
+++ b/app/src/main/java/io/github/fieldmesh/MeshtasticConnector.java
@@ -26,7 +26,8 @@ public class MeshtasticConnector {
             (byte) 0x08,
             (byte) 0x09,
             (byte) 0x0A,
-            (byte) 0x0B
+            (byte) 0x0B,
+            (byte) 0x0C
 
     );
 
@@ -41,7 +42,8 @@ public class MeshtasticConnector {
             "SEND_UUID_LIST",
             "REQUEST_UUID_DATA",
             "SEND_UUID_DATA",
-            "FINISH_SYNC"
+            "FINISH_SYNC",
+            "PLAY_AREA"
     );
 
 


### PR DESCRIPTION
## Summary
- add new `PLAY_AREA` message type to Meshtastic connector
- send play area polygons with `PLAY_AREA` type and handle them in sync service
- detect play area polygons in DB so sync requests use the new type

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d4e9130948329957581f0550efd1d