### PR TITLE
Ensure only one play area exists at a time

### DIFF
--- a/app/src/main/java/io/github/fieldmesh/MeshReceiverService.java
+++ b/app/src/main/java/io/github/fieldmesh/MeshReceiverService.java
@@ -480,6 +480,7 @@ public class MeshReceiverService extends Service implements MessageClient.OnMess
                                 PolygonInfo playAreaPoly = new PolygonInfo();
                                 playAreaPoly.decode(actualItemData);
                                 actualItemUuid = playAreaPoly.getUniqueId();
+                                mapDataDbHelper.removeAllPlayAreasExcept(actualItemUuid);
                                 if (!mapDataDbHelper.objectExists(actualItemUuid)) {
                                     mapDataDbHelper.addPolygon(playAreaPoly);
                                     Log.i(TAG, "ServiceReceiver: (Inner) PLAY_AREA " + actualItemUuid + " ADDED NEW from " + fromNodeId);


### PR DESCRIPTION
## Summary
- add helper to purge existing play areas except the current one
- remove old play areas from map, database, and peers before adding a new one
- drop prior play areas when loading saved data or receiving mesh updates

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d5618f52c8329934ce667d8d0567a